### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,14 +4,14 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   Palladio-Addons-Power-ProfilingImport:
-    runs-on: self-hosted
-    steps:
-      - uses: PalladioSimulator/Palladio-Build-ActionsPipeline@v2
-        with:
-          use-display-output: true
-          deploy-updatesite: 'releng/org.palladiosimulator.power-profilingimport.updatesite/target/repository'
-          server-ssh-key: ${{ secrets.DEPLOYMENT_SERVER_SSH_KEY }}
-          remote-host: ${{ secrets.DEPLOYMENT_REMOTE_HOST }}
-          remote-port: ${{ secrets.DEPLOYMENT_REMOTE_PORT }}
-          remote-user: ${{ secrets.DEPLOYMENT_REMOTE_USER }}
-          remote-target: ${{ secrets.DEPLOYMENT_REMOTE_TARGET }}
+    uses: PalladioSimulator/Palladio-Build-ActionsPipeline/.github/workflows/build.yml@master
+    with:
+      use-display-output: false
+      no-caching: true
+      deploy-updatesite: 'releng/org.palladiosimulator.power-profilingimport.updatesite/target/repository'
+    secrets:
+      SERVER_SSH_KEY: ${{ secrets.DEPLOYMENT_SERVER_SSH_KEY }}
+      REMOTE_HOST: ${{ secrets.DEPLOYMENT_REMOTE_HOST }}
+      REMOTE_PORT: ${{ secrets.DEPLOYMENT_REMOTE_PORT }}
+      REMOTE_USER: ${{ secrets.DEPLOYMENT_REMOTE_USER }}
+      REMOTE_TARGET: ${{ secrets.DEPLOYMENT_REMOTE_TARGET }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
 	<extension>
-		<groupId>org.eclipse.tycho.extras</groupId>
-		<artifactId>tycho-pomless</artifactId>
-		<version>2.4.0</version>
-	</extension>
-	<extension>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.6</version>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho-build</artifactId>
+		<version>2.7.5</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.8.9</version>
+		<version>0.10.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.power-profilingimport</groupId>
 	<artifactId>parent</artifactId>	
@@ -14,7 +14,7 @@
 	<packaging>pom</packaging>
 	
 	<properties>
-		<org.palladiosimulator.maven.tychotprefresh.tplocation.2>${project.basedir}/releng/org.palladiosimulator.power-profilingimport.targetplatform/tp.target</org.palladiosimulator.maven.tychotprefresh.tplocation.2>
+		<targetPlatform.relativePath>releng/org.palladiosimulator.power-profilingimport.targetplatform/tp.target</targetPlatform.relativePath>
 	</properties>
 	
 	<modules>

--- a/releng/org.palladiosimulator.power-profilingimport.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.power-profilingimport.targetplatform/tp.target
@@ -1,91 +1,45 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="org.palladiosimulator.power-profilingimport Target Platform" sequenceNumber="1">
-    <locations>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/releases/latest/"/>
-            <unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
-            <unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
-        </location>
-
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/releases/latest/"/>
-            <unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/nightly/"/>
-            <unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0"/>
-        </location>
-
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/releases/latest/"/>
-            <unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/nightly/"/>
-            <unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="0.0.0"/>
-        </location>
-
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-qual-edp2/releases/latest"/>
-            <unit id="org.palladiosimulator.edp2.feature.feature.group" version="0.0.0"/>
-            <unit id="org.palladiosimulator.edp2.ui.feature.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-qual-edp2/nightly/"/>
-            <unit id="org.palladiosimulator.edp2.feature.feature.group" version="0.0.0"/>
-            <unit id="org.palladiosimulator.edp2.ui.feature.feature.group" version="0.0.0"/>
-        </location>
-
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/releases/latest/"/>
-            <unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/nightly/"/>
-            <unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0"/>
-        </location>
-
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/releases/latest/"/>
-            <unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
-            <unit id="org.palladiosimulator.pcm.edp2.measuringpoint.feature.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
-            <unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
-            <unit id="org.palladiosimulator.pcm.edp2.measuringpoint.feature.feature.group" version="0.0.0"/>
-        </location>
-
-        <!--location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-            <unit id="org.palladiosimulator.editors.commons.feature.feature.group" version="2.1.1.201709282144"/>
-            <repository location="https://updatesite.palladio-simulator.com/palladio-editors-commons/releases/latest/"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-            <unit id="org.palladiosimulator.editors.commons.feature.feature.group" version="2.1.1.201709282144"/>
-            <repository location="https://updatesite.palladio-simulator.com/palladio-editors-commons/nightly/"/>
-        </location-->
-
-        <!--location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-            <repository location="https://updatesite.mdsd.tools/thirdparty-library/releases/latest/"/>
-            <unit id="com.google.auto.factory-annotations.feature.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-            <repository location="https://updatesite.mdsd.tools/thirdparty-library/nightly"/>
-            <unit id="com.google.auto.factory-annotations.feature.feature.group" version="0.0.0"/>
-        </location-->
-
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-library/releases/latest/"/>
-            <unit id="org.jscience.feature.feature.group" version="0.0.0"/>
-            <unit id="org.jscience.feature.source.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-            <repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-library/nightly"/>
-            <unit id="org.jscience.feature.feature.group" version="0.0.0"/>
-            <unit id="org.jscience.feature.source.feature.group" version="0.0.0"/>
-        </location>
-    </locations>
+<?pde version="3.8"?><target name="org.palladiosimulator.power-profilingimport Target Platform" sequenceNumber="2">
+	<locations>
+		<location type="Target" uri="mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03"/>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
+			<unit id="de.uka.ipd.sdq.identifier.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-metricspecification/nightly/"/>
+			<unit id="org.palladiosimulator.metricspec.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/nightly/"/>
+			<unit id="org.palladiosimulator.thirdpartywrapper.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-edp2/nightly/"/>
+			<unit id="org.palladiosimulator.edp2.feature.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.edp2.ui.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-qual-measurementframework/nightly/"/>
+			<unit id="org.palladiosimulator.measurementframework.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
+			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
+			<unit id="org.palladiosimulator.pcm.edp2.measuringpoint.feature.feature.group" version="0.0.0"/>
+		</location>
+		<!--location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<unit id="org.palladiosimulator.editors.commons.feature.feature.group" version="0.0.0"/>
+			<repository location="https://updatesite.palladio-simulator.com/palladio-editors-commons/nightly/"/>
+		</location-->
+		<!--location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.mdsd.tools/thirdparty-library/nightly"/>
+			<unit id="com.google.auto.factory-annotations.feature.feature.group" version="0.0.0"/>
+		</location-->
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-library/nightly"/>
+			<unit id="org.jscience.feature.feature.group" version="0.0.0"/>
+			<unit id="org.jscience.feature.source.feature.group" version="0.0.0"/>
+		</location>
+	</locations>
 </target>


### PR DESCRIPTION
### Overview
- Migrate from parent POM version `0.8.9` to the new parent POM version `0.10.0`
- Locally verified build success

### Changes
- In `pom.xml`:
  - Parent POM updated from `0.8.9` to `0.10.0`
  - Renamed property `org.palladiosimulator.maven.tychotprefresh.tplocation.2` to `targetPlatform.relativePath` and trimmed its path value to start at `releng`
- In `.mvn/extensions.xml`:
  - Removed `<extension>` block for `org.palladiosimulator:tycho-tp-refresh-maven-plugin`
  - Switched from `tycho-pomless:2.4.0` to `tycho-build:2.7.5`
- In the target platform `tp.target`:
  - Inserted new `<location>` with URI `mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03`, since the Palladio target platform is now decoupled from the parent POM
  - Unified all `includeSource` attributes by setting them to `false`, as the value must be the same across all locations to prevent resolution failure
  - Removed specifics of the `tycho-tp-refresh-maven-plugin` to be standard-compliant:
    - Removed any `<location filter="release">` entries
    - Removed `filter="nightly"` attributes
    - Removed all `refresh="true"` attributes and, where present, set each `<unit>`’s `version` attribute to `0.0.0`
 - Updated build.yml to latest version